### PR TITLE
Add connection failed event if host is not reachable

### DIFF
--- a/Source/SignalR/Private/Connection.cpp
+++ b/Source/SignalR/Private/Connection.cpp
@@ -73,6 +73,11 @@ void FConnection::Close(int32 Code, const FString& Reason)
     }
 }
 
+FConnection::FConnectionFailedEvent& FConnection::OnConnectionFailed()
+{
+    return OnConnectionFailedEvent;
+}
+
 IWebSocket::FWebSocketConnectedEvent& FConnection::OnConnected()
 {
     return OnConnectedEvent;
@@ -105,6 +110,14 @@ void FConnection::Negotiate()
 
 void FConnection::OnNegotiateResponse(FHttpRequestPtr InRequest, FHttpResponsePtr InResponse, bool bConnectedSuccessfully)
 {
+    if (!bConnectedSuccessfully)
+    {
+        UE_LOG(LogSignalR, Error, TEXT("Could not connect to host"))
+        OnConnectionFailedEvent.Broadcast();
+
+        return;
+    }
+
     if(InResponse->GetResponseCode() != 200)
     {
         UE_LOG(LogSignalR, Error, TEXT("Negotiate failed with status code %d"), InResponse->GetResponseCode());

--- a/Source/SignalR/Private/Connection.h
+++ b/Source/SignalR/Private/Connection.h
@@ -41,6 +41,9 @@ public:
 
     void Close(int32 Code = 1000, const FString& Reason = FString());
 
+    DECLARE_EVENT(FConnection, FConnectionFailedEvent);
+    FConnectionFailedEvent& OnConnectionFailed();
+
     IWebSocket::FWebSocketConnectedEvent& OnConnected();
 
     IWebSocket::FWebSocketConnectionErrorEvent& OnConnectionError();
@@ -58,6 +61,7 @@ private:
     FString Host;
     TMap<FString, FString> Headers;
 
+    FConnectionFailedEvent OnConnectionFailedEvent;
     IWebSocket::FWebSocketConnectedEvent OnConnectedEvent;
     IWebSocket::FWebSocketConnectionErrorEvent OnConnectionErrorEvent;
     IWebSocket::FWebSocketClosedEvent OnClosedEvent;

--- a/Source/SignalR/Private/HubConnection.cpp
+++ b/Source/SignalR/Private/HubConnection.cpp
@@ -40,6 +40,7 @@ FHubConnection::FHubConnection(const FString& InUrl, const TMap<FString, FString
     Connection = MakeShared<FConnection>(Host, InHeaders);
 
     Connection->OnConnected().AddRaw(this, &FHubConnection::OnConnectionStarted);
+    Connection->OnConnectionFailed().AddRaw(this, &FHubConnection::OnConnectionFailed);
     Connection->OnMessage().AddRaw(this, &FHubConnection::ProcessMessage);
     Connection->OnConnectionError().AddRaw(this, &FHubConnection::OnConnectionError);
     Connection->OnClosed().AddRaw(this, &FHubConnection::OnConnectionClosed);
@@ -248,6 +249,13 @@ void FHubConnection::OnConnectionStarted()
     bHandshakeReceived = false;
 
     Connection->Send(FHandshakeProtocol::CreateHandshakeMessage(HubProtocol));
+}
+
+void FHubConnection::OnConnectionFailed()
+{
+    UE_LOG(LogSignalR, Verbose, TEXT("Connection to %s failed."), *Host)
+
+    OnHubConnectionErrorEvent.Broadcast(TEXT("Could not connect to host"));
 }
 
 void FHubConnection::OnConnectionError(const FString& InError)

--- a/Source/SignalR/Private/HubConnection.h
+++ b/Source/SignalR/Private/HubConnection.h
@@ -99,6 +99,7 @@ private:
     EConnectionState ConnectionState;
 
     void OnConnectionStarted();
+    void OnConnectionFailed();
     void OnConnectionError(const FString& /* Error */);
     void OnConnectionClosed(int32 StatusCode, const FString& Reason, bool bWasClean);
 


### PR DESCRIPTION
This PR will add a new event ConnectionFailed to FConnection, which FHubConnection will listen for and emit a ConnectionErrorEvent so that the surrounding application can react to a connection failure.

Fixes crash described in #15.