### PR TITLE
Add configured connection headers to negotiation request as well

### DIFF
--- a/Source/SignalR/Private/Connection.cpp
+++ b/Source/SignalR/Private/Connection.cpp
@@ -104,6 +104,10 @@ void FConnection::Negotiate()
 
     HttpRequest->SetVerb(TEXT("POST"));
     HttpRequest->OnProcessRequestComplete().BindSP(AsShared(), &FConnection::OnNegotiateResponse);
+    for (TTuple<FString, FString> Header : Headers)
+    {
+        HttpRequest->SetHeader(Header.Key, Header.Value);
+    }
     HttpRequest->SetURL(Host + TEXT("/negotiate?negotiateVersion=1"));
     HttpRequest->ProcessRequest();
 }


### PR DESCRIPTION
To mitigate #17, add the headers that can be configured while opening the connection to the negotiation request as well. This allows to pass on e.g. a JWT token. When opening the web socket connection, these headers are already used, so authentication works correctly there.