### PR TITLE
Fix Unreal Engine 5.8 build errors

### DIFF
--- a/Source/SignalR/Private/HandshakeProtocol.cpp
+++ b/Source/SignalR/Private/HandshakeProtocol.cpp
@@ -25,16 +25,25 @@
 #include "HandshakeProtocol.h"
 #include "IHubProtocol.h"
 #include "JsonHubProtocol.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Serialization/JsonSerializer.h"
 #include "SignalRModule.h"
 
 FString FHandshakeProtocol::CreateHandshakeMessage(TSharedPtr<IHubProtocol> InProtocol)
 {
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+    TMap<UE::FSharedString, TSharedPtr<FJsonValue>> Values
+    {
+        { TEXT("protocol"), MakeShared<FJsonValueString>(InProtocol->Name().ToString()) },
+        { TEXT("version"), MakeShared<FJsonValueNumber>(InProtocol->Version()) },
+    };
+#else
     TMap<FString, TSharedPtr<FJsonValue>> Values
     {
-        { "protocol", MakeShared<FJsonValueString>(InProtocol->Name().ToString()) },
-        { "version", MakeShared<FJsonValueNumber>(InProtocol->Version()) },
-    };
+            { "protocol", MakeShared<FJsonValueString>(InProtocol->Name().ToString()) },
+            { "version", MakeShared<FJsonValueNumber>(InProtocol->Version()) },
+        };
+#endif
     TSharedPtr<FJsonObject> Obj = MakeShared<FJsonObject>();
     Obj->Values = Values;
 

--- a/Source/SignalR/Private/JsonHubProtocol.cpp
+++ b/Source/SignalR/Private/JsonHubProtocol.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "JsonHubProtocol.h"
+#include "Misc/EngineVersionComparison.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
 #include "Misc/Base64.h"
@@ -214,7 +215,11 @@ FSignalRValue DeserializeValue(TSharedPtr<FJsonValue> InValue)
             TMap<FString, FSignalRValue> OutValues;
             for (const auto& Pair : InValue->AsObject()->Values)
             {
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+                OutValues.Add(*Pair.Key, DeserializeValue(Pair.Value));
+#else
                 OutValues.Add(Pair.Key, DeserializeValue(Pair.Value));
+#endif
             }
             return FSignalRValue(MoveTemp(OutValues));
         }

--- a/Source/SignalRBlueprint/Public/SignalRValueWrapper.h
+++ b/Source/SignalRBlueprint/Public/SignalRValueWrapper.h
@@ -52,7 +52,7 @@ struct FSignalRInvokeResultWrapper : public FSignalRValueWrapper
 
     FSignalRInvokeResultWrapper() = default;
     FSignalRInvokeResultWrapper(const FSignalRInvokeResult& Value);
-    explicit FSignalRInvokeResultWrapper(const FSignalRInvokeResultWrapper& Other);
+    FSignalRInvokeResultWrapper(const FSignalRInvokeResultWrapper& Other);
     FSignalRInvokeResultWrapper(FSignalRInvokeResultWrapper&& Other) noexcept;
 
     FSignalRInvokeResultWrapper& operator=(FSignalRInvokeResultWrapper const& Other);


### PR DESCRIPTION
This PR addresses build failures that appeared while compiling the plugin with UE 5.8.

- Use shared strings commonly used by the JSON classes now
- Remove the `explicit` keyword from FSignalRInvokeResultWrapper's copy constructor, because it caused invalid conversion errors in the engine (ScriptDelegates.h, TDelegateWrapperParms constructor)